### PR TITLE
Fixed a minor fpx bug in BottomBar.ts

### DIFF
--- a/src/components/BottomBar.ts
+++ b/src/components/BottomBar.ts
@@ -172,7 +172,10 @@ export class BottomBar {
             const time = tickEvent.time;
             if (lastTime > 0) {
                 // Log FPS stats
-                const elapsedTime = time - lastTime;
+                let elapsedTime = time - lastTime;
+                if (elapsedTime < 0.001) {
+                    elapsedTime = 0.001; // it's possibly to run really fast, thus elapsedTime is 0!
+                }
                 const newFPS = 1000 / elapsedTime; // Moving average of FPS
                 totalFPS += newFPS;
                 fpsSamples.push(newFPS);


### PR DESCRIPTION
The programe is possibly to run really fast, thus elapsedTime is 0! Then `newFPS = 1000 / elapsedTime` get the invalid number - NaN, thus, we finally get NaN fps! 